### PR TITLE
Multiple items for one controller breadcrumb part

### DIFF
--- a/src/bread_crumbs_component.coffee
+++ b/src/bread_crumbs_component.coffee
@@ -13,7 +13,7 @@ defaultTemplate = """
 """
 
 BreadCrumbs.BreadCrumbsComponent = Ember.Component.extend
-  tagName: "div"
+  tagName: "ul"
   classNames: ["breadcrumbs"]
 
   layout: Ember.Handlebars.compile defaultTemplate


### PR DESCRIPTION
We should be able to define breadcrumbs that are not based on our code structure. 

```
  breadCrumbs:  [
        ['My site',]
        [dashboard, 'dashboard]
    ]
```

For instance we built disscuss board with ember.js but our main site is created in other technology.
