### PR TITLE
Fix for deprecated object proxying in ember 1.11.0

### DIFF
--- a/addon/components/bread-crumbs.js
+++ b/addon/components/bread-crumbs.js
@@ -17,7 +17,7 @@ export default Ember.Component.extend({
     var breadCrumbs = [];
 
     controllers.forEach(function(controller, index) {
-      var crumbName = controller.get("breadCrumb");
+      var crumbName = controller.get("model.breadCrumb");
       if (!Ember.isEmpty(crumbName)) {
         var defaultPath = defaultPaths[index];
         var specifiedPath = controller.get("breadCrumbPath");


### PR DESCRIPTION
I'm using using ember beta and I'm getting the following error for routes doesn't have breadCrumb property in it's controllers :

"DEPRECATION: You attempted to access `breadCrumb` from `(generated home.error controller)`, but object proxying is deprecated. Please use `model.breadCrumb` instead.

So I simply did that and everything worked fine in my application.
Hope this help.