### PR TITLE
Fixes for deprecated items in Ember 1.13.0

### DIFF
--- a/app/templates/components/bread-crumbs.hbs
+++ b/app/templates/components/bread-crumbs.hbs
@@ -1,6 +1,6 @@
 <ul class="breadcrumbs">
-  {{#each crumb in breadCrumbs}}
-    <li {{bind-attr class="crumb.isCurrent:current:"}}>
+  {{#each breadCrumbs as |crumb|}}
+    <li class={{if crumb.isCurrent 'current'}}>
       {{#if crumb.linkable}}
         {{#if crumb.model}}{{! to avoid null/undefined model in link-to }}
           {{#link-to crumb.path crumb.model}}


### PR DESCRIPTION
I'm using this with 1.13.0-beta.2.  `bind-attr` is deprecated, and the template iterator should be `#each collection as |item|`.