### PR TITLE
Fixes deprecation initializer for Ember 2.x

### DIFF
--- a/app/initializers/bread-crumbs.js
+++ b/app/initializers/bread-crumbs.js
@@ -1,13 +1,8 @@
 export default {
   name: "ember-breadcrumbs",
   initialize: function() {
-    //pre 2.x
-    if(arguments.length > 1) {
-      arguments[1].inject("component:bread-crumbs", "router", "router:main");
-      arguments[1].inject("component:bread-crumbs", "applicationController", "controller:application");  
-    } else {
-      arguments[0].inject("component:bread-crumbs", "router", "router:main");
-      arguments[0].inject("component:bread-crumbs", "applicationController", "controller:application");  
-    }
+    let application = arguments[1] || arguments[0];
+    application.inject("component:bread-crumbs", "router", "router:main");
+    application.inject("component:bread-crumbs", "applicationController", "controller:application");
   }
 };

--- a/app/initializers/bread-crumbs.js
+++ b/app/initializers/bread-crumbs.js
@@ -1,7 +1,13 @@
 export default {
   name: "ember-breadcrumbs",
-  initialize: function(container, app) {
-    app.inject("component:bread-crumbs", "router", "router:main");
-    app.inject("component:bread-crumbs", "applicationController", "controller:application");
+  initialize: function() {
+    //pre 2.x
+    if(arguments.length > 1) {
+      arguments[1].inject("component:bread-crumbs", "router", "router:main");
+      arguments[1].inject("component:bread-crumbs", "applicationController", "controller:application");  
+    } else {
+      arguments[0].inject("component:bread-crumbs", "router", "router:main");
+      arguments[0].inject("component:bread-crumbs", "applicationController", "controller:application");  
+    }
   }
 };


### PR DESCRIPTION
DEPRECATION: The `initialize` method for Application initializer 'ember-breadcrumbs' should take only one argument - `App`, an instance of an `Application`. [deprecation id: ember-application.app-initializer-initialize-arguments] See http://emberjs.com/deprecations/v2.x/#toc_initializer-arity for more details.