### PR TITLE
Fix regression where default path is no longer applied

### DIFF
--- a/addon/components/bread-crumbs.js
+++ b/addon/components/bread-crumbs.js
@@ -52,7 +52,7 @@ export default Ember.Component.extend({
       crumbs.forEach(function (crumb) {
         breadCrumbs.addObject(Ember.Object.create({
           label: crumb.label,
-          path: crumb.path,
+          path: crumb.path || defaultPaths[index],
           model: crumb.model,
           linkable: Ember.isPresent(crumb.linkable) ? crumb.linkable : crumb.path !== false,
           isCurrent: false


### PR DESCRIPTION
*Problem*: Crumbs with no path specified does not work anymore.


This seems to have been removed in this commit.

https://github.com/chrisfarber/ember-breadcrumbs/commit/946eea4646bc1134df4c3a35e7ec74100164388f

I'm assuming it was accidental since otherwise `defaultPaths` is never used. 

