### PR TITLE
Fix deprecation warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,9 @@
   },
   "author": "Chris Farber",
   "license": "MIT",
+  "dependencies": {
+    "ember-cli-babel": "^4.3.0"
+  },
   "devDependencies": {
     "broccoli-asset-rev": "^2.0.0",
     "ember-cli": "0.2.0",
@@ -24,7 +27,6 @@
     "ember-cli-dependency-checker": "0.0.8",
     "ember-cli-content-security-policy": "0.3.0",
     "ember-cli-htmlbars": "0.7.4",
-    "ember-cli-babel": "^4.3.0",
     "ember-cli-ic-ajax": "0.1.1",
     "ember-cli-inject-live-reload": "^1.3.0",
     "ember-cli-qunit": "0.3.9",


### PR DESCRIPTION
Moving `ember-cli-babel` to the `dependencies` hash to alleviate a deprecation warning.