### PR TITLE
Update babel dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "author": "Chris Farber",
   "license": "MIT",
   "dependencies": {
-    "ember-cli-babel": "^4.3.0"
+    "ember-cli-babel": "^6.0.0"
   },
   "devDependencies": {
     "broccoli-asset-rev": "^2.0.0",


### PR DESCRIPTION
`ember-cli-babel@4` is really quite old, with the latest release this is the only addon that pulls in version 4 (and all the related dependencies), which is a lot of bloat! This MR pins it to 6.