### PR TITLE
Fix router usage to remove deprecation warning

### DIFF
--- a/addon/components/bread-crumbs.js
+++ b/addon/components/bread-crumbs.js
@@ -5,7 +5,7 @@ export default Ember.Component.extend({
   applicationController: null,
 
   handlerInfos: Ember.computed("applicationController.currentPath", function() {
-    return this.get("router").router.currentHandlerInfos;
+    return this.get("router")._routerMicrolib.currentHandlerInfos;
   }),
 
   /*

--- a/addon/components/bread-crumbs.js
+++ b/addon/components/bread-crumbs.js
@@ -5,7 +5,8 @@ export default Ember.Component.extend({
   applicationController: null,
 
   handlerInfos: Ember.computed("applicationController.currentPath", function() {
-    return this.get("router")._routerMicrolib.currentHandlerInfos;
+    var router = this.get("router")._routerMicrolib || this.get("router").router;
+    return router.currentHandlerInfos;
   }),
 
   /*


### PR DESCRIPTION
This deprecation warning was appearing:
```
ember.debug.js:7748 DEPRECATION: Usage of `router` is deprecated, use `_routerMicrolib` instead. [deprecation id: ember-router.router] See http://emberjs.com/deprecations/v2.x/#toc_ember-router-router-renamed-to-ember-router-_routermicrolib for more details.
```

Screenshot of the warning: https://puu.sh/w0V3V/1e8bae19ff.png

Fixed as advised by the warning.